### PR TITLE
avoid loop for closed polygons

### DIFF
--- a/lib/algorithms/point_in_polygon.rb
+++ b/lib/algorithms/point_in_polygon.rb
@@ -43,7 +43,7 @@ module Geometry
     end
 
     def good_ray?(ray)
-      edges.none? { |edge| edge.parallel_to?(ray) } && vertices.none? { |vertex| ray.contains_point?(vertex) }
+      edges.none? { |edge| !edge.length.zero? && edge.parallel_to?(ray) } && vertices.none? { |vertex| ray.contains_point?(vertex) }
     end
     
     def intersection_count(ray)


### PR DESCRIPTION
Hi Daniel,
Thank you very much for ruby-geometry :-)
I've modified **good_ray** to avoid infinite loops, in case of closed polygons.
What I mean by "closed polygon", is a polygon which is defined by points A, B, C, D, A for example.
In such case, the function would return false infinitely.