### PR TITLE
Deterministic algorithm to determine whether a point is in a polygon

### DIFF
--- a/lib/geometry/algorithms/point_in_polygon.rb
+++ b/lib/geometry/algorithms/point_in_polygon.rb
@@ -43,7 +43,8 @@ module Geometry
       vertices.each_with_index do |vertex, i|
         previous_vertex = vertices[i - 1] || vertex.last
         if ((vertex.y > point.y) != (previous_vertex.y > point.y)) &&
-            (point.x < (previous_vertex.x - vertex.x) * (point.y - vertex.y) / (previous_vertex.y - vertex.y) + vertex.x)
+           (point.x < (previous_vertex.x - vertex.x) * (point.y - vertex.y) /
+            (previous_vertex.y - vertex.y) + vertex.x)
           result = !result
         end
       end

--- a/lib/geometry/polygon.rb
+++ b/lib/geometry/polygon.rb
@@ -13,25 +13,13 @@ module Geometry
     def bounding_box
       leftbottom = Point vertices.map(&:x).min, vertices.map(&:y).min
       righttop = Point vertices.map(&:x).max, vertices.map(&:y).max
-
+      
       BoundingBox.new leftbottom, righttop
     end
 
     def contains?(point)
-      # Algorithm source:
-      # https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
-
-      result = false
-
-      vertices.each_with_index do |vertex, i|
-        previous_vertex = vertices[i - 1] || vertex.last
-        if ((vertex.y > point.y) != (previous_vertex.y > point.y)) &&
-            (point.x < (previous_vertex.x - vertex.x) * (point.y - vertex.y) / (previous_vertex.y - vertex.y) + vertex.x)
-          result = !result
-        end
-      end
-
-      result
+      point_in_polygon = PointInPolygon.new(point, self)
+      point_in_polygon.inside? || point_in_polygon.on_the_boundary?
     end
 
     def area

--- a/lib/geometry/polygon.rb
+++ b/lib/geometry/polygon.rb
@@ -13,13 +13,25 @@ module Geometry
     def bounding_box
       leftbottom = Point vertices.map(&:x).min, vertices.map(&:y).min
       righttop = Point vertices.map(&:x).max, vertices.map(&:y).max
-      
+
       BoundingBox.new leftbottom, righttop
     end
 
     def contains?(point)
-      point_in_polygon = PointInPolygon.new(point, self)
-      point_in_polygon.inside? || point_in_polygon.on_the_boundary?
+      # Algorithm source:
+      # https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
+
+      result = false
+
+      vertices.each_with_index do |vertex, i|
+        previous_vertex = vertices[i - 1] || vertex.last
+        if ((vertex.y > point.y) != (previous_vertex.y > point.y)) &&
+            (point.x < (previous_vertex.x - vertex.x) * (point.y - vertex.y) / (previous_vertex.y - vertex.y) + vertex.x)
+          result = !result
+        end
+      end
+
+      result
     end
 
     def area


### PR DESCRIPTION
I haven't gotten a chance to spend much time with this, but I've dropped in the algorithm I'm using in  my application to replace `Polygon.contains?`.

There's one failing test, which is the check for a point being on the edge of a convex polygon. As stated in the section [Point on a (Boundary) Edge](https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html#Point%20on%20an%20Edge) from the algorithm's source page, this algorithm isn't able to predict when a point is exactly on the edge of a polygon. Perhaps a hybrid of this new algorithm with your current algorithm will do the trick.

Feel free to mess around with this and push commits to my branch.